### PR TITLE
Set the treeID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 toto*
 *-global.po
 *-temp.po
+.vscode

--- a/fontoj/PersonFS/Importo.py
+++ b/fontoj/PersonFS/Importo.py
@@ -743,6 +743,7 @@ class FsAlGr:
     self.notoj = False
     self.fontoj = False
     self.vorteco = 0
+    self.tree_id = "GLOBAL"
     self.aldonaPersono = False
     self.refresxigxo = True
   def aldPersono(self, db, txn, fsPersono):
@@ -836,6 +837,8 @@ class FsAlGr:
     if not PersonFS.PersonFS.aki_sesio(vokanto,self.vorteco):
       WarningDialog(_('Ne konekta al FamilySearch'))
       return
+    set_trees_id(self.vorteco, self.tree_id)
+
     if not utila.fs_gr :
       utila.konstrui_fs_gr(vokanto,progress,11)
     #if not tree._FsSeanco:
@@ -1197,6 +1200,9 @@ class FSImportoOpcionoj(MenuToolOptions):
     self.__gui_notoj = BooleanOption(_("Aldoni notoj"), False)
     self.__gui_notoj.set_help(_("Aldoni notoj"))
     menu.add_option(category_name, "gui_notoj", self.__gui_notoj)
+    self.__gui_tree = StringOption(_("Tree ID"), "GLOBAL")
+    self.__gui_tree.set_help(_("FamilySearch tree ID"))
+    menu.add_option(category_name, "gui_tree", self.__gui_tree)
     self.__gui_vort = NumberOption(_("Vorteco"), 0, 0, 3)
     self.__gui_vort.set_help(_("Vorteca nivelo de 0 (minimuma) ĝis 3 (tre vorta)"))
     menu.add_option(category_name, "gui_vort", self.__gui_vort)
@@ -1208,6 +1214,27 @@ class FSImportoOpcionoj(MenuToolOptions):
     if PersonFS.PersonFS.FSID :
       self.handler.options_dict['FS_ID'] = PersonFS.PersonFS.FSID
     return
+
+def set_trees_id(vorteco, tree_id="GLOBAL"):
+  url = "https://api.familysearch.org/platform/trees/current"
+  payload = {
+    "trees": [
+      {
+        "id": tree_id
+      }
+    ]
+  }
+  print("Set trees ID request: "+json.dumps(payload))
+  headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, */*"
+  }
+  r = tree._FsSeanco.post_url(url, json.dumps(payload), headers)
+  if vorteco:
+    print(f"Set trees ID response: {r.status_code} - {r.text}")
+    r = tree._FsSeanco.get_url(url, headers)
+    print(f"Get current tree response: {r.status_code} - {r.text}")
+  return True
 
 class FSImporto(PluginWindows.ToolManagedWindowBatch):
   """
@@ -1259,6 +1286,7 @@ class FSImporto(PluginWindows.ToolManagedWindowBatch):
     importilo.edz = menu.get_option_by_name('gui_edz').get_value()
     importilo.notoj = menu.get_option_by_name('gui_notoj').get_value()
     importilo.fontoj = menu.get_option_by_name('gui_fontoj').get_value()
+    importilo.tree_id = menu.get_option_by_name('gui_tree').get_value()
     importilo.nereimporti = menu.get_option_by_name('gui_nereimporti').get_value()
     importilo.vorteco = menu.get_option_by_name('gui_vort').get_value()
 

--- a/fontoj/PersonFS/tree.py
+++ b/fontoj/PersonFS/tree.py
@@ -81,16 +81,20 @@ class Tree(gedcomx_v1.Gedcomx):
     """add individuals to the family tree
     :param fids: an iterable of fid
     """
-    async def sxargi_personoj(loop,fids):
+#    async def sxargi_personoj(loop,fids):
+    async def sxargi_personoj(fids):
+      loop = asyncio.get_running_loop()
       farindajxoj = set()
       for fid in fids :
-        if fid not in self._persons.keys() :
+#        if fid not in self._persons.keys() :
+        if fid not in self._persons:
           farindajxoj.add(loop.run_in_executor(None,self.add_persono,fid))
       for farindajxo in farindajxoj :
         await farindajxo
         
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete( sxargi_personoj(loop,fids))
+#    loop = asyncio.get_event_loop()
+#    loop.run_until_complete( sxargi_personoj(loop,fids))
+    asyncio.run(sxargi_personoj(fids))
 
     for fid in fids :
       if fid in gedcomx_v1.Person._indekso :


### PR DESCRIPTION
Family search offers the possibility to create different family trees so that you can control the visibility of living family members. With this patch you can select the family search family tree ID.